### PR TITLE
Add mixin

### DIFF
--- a/models/omnimamba.py
+++ b/models/omnimamba.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 from typing import Optional, Type
 
+from huggingface_hub import PyTorchModelHubMixin
+
 import torch
 from torch import nn
-import random
 from models.cobra.backbones.llm.prompting import PromptBuilder
 from models.cobra.overwatch import initialize_overwatch
 from models.cobra.nn_utils import FusedMLPProjector, LinearProjector, MLPProjector, FusedLDPProjector
@@ -39,7 +40,12 @@ def print_trainable_parameters(model):
             print(f"  {name}: {param.numel()}")
 
 
-class OmniMamba(nn.Module):
+class OmniMamba(nn.Module,
+                PyTorchModelHubMixin,
+                repo_url="https://github.com/hustvl/OmniMamba",
+                paper_url="https://arxiv.org/abs/2407.11015",
+                pipeline_tag="any-to-any",
+                license="mit"):
     def __init__(
         self,
         args,


### PR DESCRIPTION
This PR improves the Hugging Face integration. It showcases the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class to automatically push and load the OmniMamba checkpoint to/from the hub. It comes with:

* safetensors for weights serialization
* automatic download stats
* `from_pretrained` and `push_to_hub` methods for your class.

It can be tried out as follows from this branch (requires `pip install --upgrade git+https://github.com/huggingface/huggingface_hub.git`)

```python
from models.omnimamba import OmniMamba
import torch

# load model
model = OmniMamba(...)

# equip with weights
filepath = hf_hub_download(repo_id="hustvl/OmniMamba", filename="OmniMamba-1.3b.pth")
state_dict = torch.load(filepath, map_location="cpu")
model.load_state_dict(state_dict)

# push to the hub
model.push_to_hub("hustvl-OmniMamba")

# now anyone can use it as follows
model = OmniMamba.from_pretrained("hustvl/OmniMamba")
```

Could you try this out?